### PR TITLE
Ensure subscription buttons use i18n translations

### DIFF
--- a/app/bot/handlers/menu.py
+++ b/app/bot/handlers/menu.py
@@ -23,10 +23,19 @@ async def menu_profile(cq: CallbackQuery, state: FSMContext, t, lang: str):
 @router.callback_query(F.data == "menu:subs")
 async def menu_subs(cq: CallbackQuery, t, settings, lang: str):
     text = t("subs.title").replace("{TZ}", getattr(settings, "TZ", "UTC"))
-    kb = InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text="⚡️ Мгновенно" if lang == "ru" else "⚡️ Instant", callback_data="subs:instant"), InlineKeyboardButton(text="🗓 Ежедневно" if lang == "ru" else "🗓 Daily", callback_data="subs:daily"), InlineKeyboardButton(text="📅 Еженедельно" if lang == "ru" else "📅 Weekly", callback_data="subs:weekly")],
-        [InlineKeyboardButton(text="🔔 Вкл/Выкл" if lang == "ru" else "🔔 On/Off", callback_data="subs:toggle"), InlineKeyboardButton(text="⏰ Изменить время" if lang == "ru" else "⏰ Change time", callback_data="subs:time")],
-    ])
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text=t("buttons.subs.instant"), callback_data="subs:instant"),
+                InlineKeyboardButton(text=t("buttons.subs.daily"), callback_data="subs:daily"),
+                InlineKeyboardButton(text=t("buttons.subs.weekly"), callback_data="subs:weekly"),
+            ],
+            [
+                InlineKeyboardButton(text=t("buttons.subs.toggle"), callback_data="subs:toggle"),
+                InlineKeyboardButton(text=t("buttons.subs.time"), callback_data="subs:time"),
+            ],
+        ]
+    )
     kb = with_lang_row(kb, lang, t)
     await cq.message.answer(text, reply_markup=kb)
     await cq.answer("")

--- a/app/bot/handlers/subscriptions.py
+++ b/app/bot/handlers/subscriptions.py
@@ -13,8 +13,17 @@ async def subs_cmd(m: Message, t, settings, lang: str):
     # Simple subscriptions screen per spec
     # Timezone read from settings if present, using cfg only for placeholder
     text = t("subs.title").replace("{TZ}", getattr(settings, "TZ", "UTC"))
-    kb = InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text="⚡️ Мгновенно" if lang == "ru" else "⚡️ Instant", callback_data="subs:instant"), InlineKeyboardButton(text="🗓 Ежедневно" if lang == "ru" else "🗓 Daily", callback_data="subs:daily"), InlineKeyboardButton(text="📅 Еженедельно" if lang == "ru" else "📅 Weekly", callback_data="subs:weekly")],
-        [InlineKeyboardButton(text="🔔 Вкл/Выкл" if lang == "ru" else "🔔 On/Off", callback_data="subs:toggle"), InlineKeyboardButton(text="⏰ Изменить время" if lang == "ru" else "⏰ Change time", callback_data="subs:time")],
-    ])
-    await m.answer(text, reply_markup=with_lang_row(kb, lang))
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text=t("buttons.subs.instant"), callback_data="subs:instant"),
+                InlineKeyboardButton(text=t("buttons.subs.daily"), callback_data="subs:daily"),
+                InlineKeyboardButton(text=t("buttons.subs.weekly"), callback_data="subs:weekly"),
+            ],
+            [
+                InlineKeyboardButton(text=t("buttons.subs.toggle"), callback_data="subs:toggle"),
+                InlineKeyboardButton(text=t("buttons.subs.time"), callback_data="subs:time"),
+            ],
+        ]
+    )
+    await m.answer(text, reply_markup=with_lang_row(kb, lang, t))

--- a/app/bot/i18n/en.json
+++ b/app/bot/i18n/en.json
@@ -121,6 +121,11 @@
   "buttons.search.reset": "♻️ Reset",
   "buttons.back": "⬅️ Back",
   "buttons.more": "➡️ More",
+  "buttons.subs.instant": "⚡️ Instant",
+  "buttons.subs.daily": "🗓 Daily",
+  "buttons.subs.weekly": "📅 Weekly",
+  "buttons.subs.toggle": "🔔 On/Off",
+  "buttons.subs.time": "⏰ Change time",
   "chips.search.clear_category": "🧹 Clear category",
   "chips.search.days_30": "⏳ days=30",
   "chips.search.add_remote": "🌐 Add Remote"

--- a/app/bot/i18n/ru.json
+++ b/app/bot/i18n/ru.json
@@ -121,6 +121,11 @@
   "buttons.search.reset": "♻️ Сброс",
   "buttons.back": "⬅️ Назад",
   "buttons.more": "➡️ Ещё",
+  "buttons.subs.instant": "⚡️ Мгновенно",
+  "buttons.subs.daily": "🗓 Ежедневно",
+  "buttons.subs.weekly": "📅 Еженедельно",
+  "buttons.subs.toggle": "🔔 Вкл/Выкл",
+  "buttons.subs.time": "⏰ Изменить время",
   "chips.search.clear_category": "🧹 Снять category",
   "chips.search.days_30": "⏳ days=30",
   "chips.search.add_remote": "🌐 Добавить Remote"


### PR DESCRIPTION
## Summary
- move subscription button labels to i18n files
- render subscription menus using translated labels

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6dadbb0988322ac1b79b9db57d8ef