### PR TITLE
Add health server to run on Render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,12 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
-    DEBIAN_FRONTEND=noninteractive
+    DEBIAN_FRONTEND=noninteractive \
+    PORT=8080
 
 WORKDIR /app
+
+EXPOSE 8080
 
 # System deps (quiet, noninteractive)
 RUN apt-get update -qq \

--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 
+from aiohttp import web
 from aiogram import Router
-from aiogram.enums import ParseMode
 
 from app.bot.handlers import health as h_health
 from app.bot import anchor as h_anchor
@@ -16,6 +17,18 @@ from app.container import build_container
 async def main() -> None:
     c = await build_container()
 
+    # Lightweight web server for Render.com health checks
+    async def http_health(_: web.Request) -> web.Response:
+        return web.Response(text="OK")
+
+    app = web.Application()
+    app.router.add_get("/", http_health)
+    port = int(os.environ.get("PORT", "8080"))
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", port)
+    await site.start()
+
     # Middlewares
     ru = json.loads(Path("app/bot/i18n/ru.json").read_text("utf-8"))
     en = json.loads(Path("app/bot/i18n/en.json").read_text("utf-8"))
@@ -23,8 +36,16 @@ async def main() -> None:
     c.dp.callback_query.middleware(I18nMiddleware(ru, en))
     c.dp.message.middleware(InjectSessionMiddleware(c.dp["session_factory"]))
     c.dp.callback_query.middleware(InjectSessionMiddleware(c.dp["session_factory"]))
-    c.dp.message.middleware(InjectDepsMiddleware(cfg=c.dp["cfg"], adzuna=c.dp["adzuna"], store=c.dp["store"], settings=c.dp["settings"]))
-    c.dp.callback_query.middleware(InjectDepsMiddleware(cfg=c.dp["cfg"], adzuna=c.dp["adzuna"], store=c.dp["store"], settings=c.dp["settings"]))
+    c.dp.message.middleware(
+        InjectDepsMiddleware(
+            cfg=c.dp["cfg"], adzuna=c.dp["adzuna"], store=c.dp["store"], settings=c.dp["settings"],
+        ),
+    )
+    c.dp.callback_query.middleware(
+        InjectDepsMiddleware(
+            cfg=c.dp["cfg"], adzuna=c.dp["adzuna"], store=c.dp["store"], settings=c.dp["settings"],
+        ),
+    )
     c.dp.message.middleware(RateLimitMiddleware(c.cfg.ratelimit.per_user_per_minute, c.store))
 
     # Routers


### PR DESCRIPTION
## Summary
- serve a tiny aiohttp app for Render health checks
- expose port 8080 for container deployments

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e5cbfd508322833167d8df90a2a9