### PR TITLE
Fix SQLite deployment by using JSON fields instead of ARRAY

### DIFF
--- a/app/infra/db_models.py
+++ b/app/infra/db_models.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Integer, JSON, String, Text
-from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .db import Base
@@ -26,12 +25,12 @@ class Profile(Base):
     __tablename__ = "profiles"
     user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
     role: Mapped[str | None] = mapped_column(Text)
-    employment_types: Mapped[list[str] | None] = mapped_column(ARRAY(String))
-    skills: Mapped[list[str] | None] = mapped_column(ARRAY(String))
-    locations: Mapped[list[str] | None] = mapped_column(ARRAY(String))
+    employment_types: Mapped[list[str] | None] = mapped_column(JSON)
+    skills: Mapped[list[str] | None] = mapped_column(JSON)
+    locations: Mapped[list[str] | None] = mapped_column(JSON)
     salary_min: Mapped[int | None] = mapped_column(Integer)
     salary_max: Mapped[int | None] = mapped_column(Integer)
-    formats: Mapped[list[str] | None] = mapped_column(ARRAY(String))
+    formats: Mapped[list[str] | None] = mapped_column(JSON)
     experience_yrs: Mapped[int | None] = mapped_column(Integer)
 
 

--- a/app/infra/migrations/versions/0001_initial.py
+++ b/app/infra/migrations/versions/0001_initial.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 
 revision = "0001_initial"
@@ -23,11 +22,11 @@ def upgrade() -> None:
         "profiles",
         sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
         sa.Column("role", sa.Text()),
-        sa.Column("skills", postgresql.ARRAY(sa.String())),
-        sa.Column("locations", postgresql.ARRAY(sa.String())),
+        sa.Column("skills", sa.JSON()),
+        sa.Column("locations", sa.JSON()),
         sa.Column("salary_min", sa.Integer()),
         sa.Column("salary_max", sa.Integer()),
-        sa.Column("formats", postgresql.ARRAY(sa.String())),
+        sa.Column("formats", sa.JSON()),
         sa.Column("experience_yrs", sa.Integer()),
     )
     op.create_table(
@@ -76,7 +75,7 @@ def upgrade() -> None:
         sa.Column("at", sa.DateTime(timezone=True)),
         sa.Column("user_id", sa.BigInteger()),
         sa.Column("action", sa.Text()),
-        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text())),
+        sa.Column("payload", sa.JSON()),
     )
 
 

--- a/app/infra/migrations/versions/0002_ui_sessions_and_profile_ext.py
+++ b/app/infra/migrations/versions/0002_ui_sessions_and_profile_ext.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 
 revision = "0002_ui_sessions_and_profile_ext"
@@ -15,7 +14,7 @@ def upgrade() -> None:
     # users.full_name
     op.add_column("users", sa.Column("full_name", sa.Text(), nullable=True))
     # profiles.employment_types
-    op.add_column("profiles", sa.Column("employment_types", postgresql.ARRAY(sa.String()), nullable=True))
+    op.add_column("profiles", sa.Column("employment_types", sa.JSON(), nullable=True))
     # ui_sessions table
     op.create_table(
         "ui_sessions",
@@ -23,7 +22,7 @@ def upgrade() -> None:
         sa.Column("user_id", sa.BigInteger(), primary_key=True),
         sa.Column("anchor_message_id", sa.BigInteger(), nullable=True),
         sa.Column("screen_state", sa.String(length=64), nullable=False, server_default="welcome"),
-        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default="{}"),
+        sa.Column("payload", sa.JSON(), nullable=False, server_default="{}"),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
     )
 


### PR DESCRIPTION
## Summary
- store list-like profile fields as JSON instead of Postgres-only ARRAY
- update migrations to use generic JSON columns

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ebb02ddc832287c29b2b2711d84c