### PR TITLE
Fix polling conflict by clearing webhook

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,8 @@ from app.container import build_container
 
 async def main() -> None:
     c = await build_container()
+    # Ensure no leftover webhooks interfere with polling
+    await c.bot.delete_webhook(drop_pending_updates=True)
 
     # Lightweight web server for Render.com health checks
     async def http_health(_: web.Request) -> web.Response:


### PR DESCRIPTION
## Summary
- Remove any lingering Telegram webhook before starting long polling to prevent `TelegramConflictError`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7f25975dc8322b5bcbf1f9a306996