### PR TITLE
Handle Telegram conflict errors gracefully

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from aiohttp import web
 from aiogram import Router
+from aiogram.exceptions import TelegramConflictError
 
 from app.bot.handlers import health as h_health
 from app.bot import anchor as h_anchor
@@ -66,6 +67,11 @@ async def main() -> None:
 
     try:
         await c.dp.start_polling(c.bot)
+    except TelegramConflictError:
+        print(
+            "Another bot instance is already running. Exiting.",
+            file=sys.stderr,
+        )
     finally:
         await c.store.delete(lock_key)
 


### PR DESCRIPTION
## Summary
- gracefully exit when another instance is already polling the bot

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b7f6d4c83483228cb0952e75c89be0