### PR TITLE
Silence Telegram polling conflicts

### DIFF
--- a/app/container.py
+++ b/app/container.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from aiogram import Bot, Dispatcher
+from aiogram import Bot
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from app.config import AppConfig, Settings, load_app_config
 from app.infra.db import Base, make_engine, make_session_factory
 from app.infra.redis import InMemoryStore, KeyValueStore, RedisStore
+from app.infra.dispatcher import Dispatcher
 from app.integrations.adzuna_client import AdzunaClient
 from app.telemetry.logger import setup_logging
 

--- a/app/infra/dispatcher.py
+++ b/app/infra/dispatcher.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator, List, Optional
+
+from aiogram import loggers
+from aiogram.client.bot import Bot
+from aiogram.dispatcher.dispatcher import (
+    DEFAULT_BACKOFF_CONFIG,
+    Dispatcher as AiogramDispatcher,
+)
+from aiogram.exceptions import TelegramConflictError
+from aiogram.methods import GetUpdates
+from aiogram.types import Update
+from aiogram.utils.backoff import Backoff, BackoffConfig
+
+
+class Dispatcher(AiogramDispatcher):
+    """Dispatcher that suppresses TelegramConflictError noise."""
+
+    @classmethod
+    async def _listen_updates(
+        cls,
+        bot: Bot,
+        polling_timeout: int = 30,
+        backoff_config: BackoffConfig = DEFAULT_BACKOFF_CONFIG,
+        allowed_updates: Optional[List[str]] = None,
+    ) -> AsyncGenerator[Update, None]:
+        backoff = Backoff(config=backoff_config)
+        get_updates = GetUpdates(timeout=polling_timeout, allowed_updates=allowed_updates)
+        kwargs = {}
+        if bot.session.timeout:
+            kwargs["request_timeout"] = int(bot.session.timeout + polling_timeout)
+        failed = False
+        while True:
+            try:
+                updates = await bot(get_updates, **kwargs)
+            except TelegramConflictError:
+                # Another long-polling session is running; exit silently
+                return
+            except Exception as e:  # pragma: no cover - network failures
+                failed = True
+                loggers.dispatcher.error(
+                    "Failed to fetch updates - %s: %s", type(e).__name__, e
+                )
+                loggers.dispatcher.warning(
+                    "Sleep for %f seconds and try again... (tryings = %d, bot id = %d)",
+                    backoff.next_delay,
+                    backoff.counter,
+                    bot.id,
+                )
+                await backoff.asleep()
+                continue
+            if failed:
+                loggers.dispatcher.info(
+                    "Connection established (tryings = %d, bot id = %d)",
+                    backoff.counter,
+                    bot.id,
+                )
+                backoff.reset()
+                failed = False
+            for update in updates:
+                yield update
+                get_updates.offset = update.update_id + 1

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -1,0 +1,26 @@
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from aiogram.exceptions import TelegramConflictError
+from aiogram.methods import GetUpdates
+
+from app.infra.dispatcher import Dispatcher
+
+
+class DummyBot:
+    def __init__(self):
+        self.session = SimpleNamespace(timeout=None)
+        self.id = 42
+
+    async def __call__(self, method, **kwargs):  # pragma: no cover - network not used
+        raise TelegramConflictError(GetUpdates(), "conflict")
+
+
+@pytest.mark.asyncio
+async def test_conflict_suppressed():
+    bot = DummyBot()
+    gen = Dispatcher._listen_updates(bot)
+    updates = [u async for u in gen]
+    assert updates == []


### PR DESCRIPTION
## Summary
- use custom dispatcher that exits cleanly on TelegramConflictError
- wire new dispatcher into container
- test conflict suppression behavior

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7fecea90c8322ac8876a6c96539cc