### PR TITLE
Handle polling conflicts without stopping

### DIFF
--- a/app/infra/dispatcher.py
+++ b/app/infra/dispatcher.py
@@ -35,8 +35,12 @@ class Dispatcher(AiogramDispatcher):
             try:
                 updates = await bot(get_updates, **kwargs)
             except TelegramConflictError:
-                # Another long-polling session is running; exit silently
-                return
+                loggers.dispatcher.info(
+                    "Polling conflict detected; retrying... (bot id = %d)",
+                    bot.id,
+                )
+                await backoff.asleep()
+                continue
             except Exception as e:  # pragma: no cover - network failures
                 failed = True
                 loggers.dispatcher.error(


### PR DESCRIPTION
## Summary
- retry long polling when Telegram returns a conflict instead of exiting
- adjust conflict test for retry behaviour

## Testing
- `ruff .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68b801446654832295edc6401fdd3c60