### PR TITLE
Handle polling conflict retries and avoid BuildKit requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@
 COMPOSE := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
 PRETTY := bash ./scripts/pretty.sh
 
+# Disable BuildKit to avoid depending on buildkitd in restricted environments
+export DOCKER_BUILDKIT ?= 0
+export COMPOSE_DOCKER_CLI_BUILD ?= 0
+
 check-docker:
 	@# Ensure Docker CLI is installed
 	@if ! command -v docker >/dev/null 2>&1; then \


### PR DESCRIPTION
## Summary
- allow dispatcher to retry on polling conflicts without blocking cancellation
- avoid BuildKit requirement by disabling it in Makefile

## Testing
- `ruff app/infra/dispatcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b802df2e508322a18de8ea86b5b44f