### PR TITLE
Respect salary filter in Adzuna job searches

### DIFF
--- a/app/bot/anchor.py
+++ b/app/bot/anchor.py
@@ -763,7 +763,16 @@ async def search_show(cq: CallbackQuery, session, cfg: AppConfig, adzuna: Adzuna
     )
     params = SearchParams(max_days_old=cfg.search.max_days_old_default, sort="relevance")
     try:
-        results = await adzuna.search("gb", 1, cfg.search.results_per_page, what=profile.role or None, where=(payload.get("filters", {}).get("where") or None), sort=params.sort, max_days_old=params.max_days_old)
+        results = await adzuna.search(
+            "gb",
+            1,
+            cfg.search.results_per_page,
+            what=profile.role or None,
+            where=(payload.get("filters", {}).get("where") or None),
+            sort=params.sort,
+            max_days_old=params.max_days_old,
+            salary_min=profile.salary_min or None,
+        )
     except Exception:
         results = []
     pr = process(results, profile, params, cfg)

--- a/app/bot/handlers/search.py
+++ b/app/bot/handlers/search.py
@@ -96,7 +96,16 @@ async def find_cmd(
     )
     params = SearchParams(max_days_old=cfg.search.max_days_old_default, sort="relevance")
     try:
-        results = await adzuna.search("gb", 1, cfg.search.results_per_page, what=profile.role, where=profile.locations[0] if profile.locations else None, sort=params.sort, max_days_old=params.max_days_old)
+        results = await adzuna.search(
+            "gb",
+            1,
+            cfg.search.results_per_page,
+            what=profile.role,
+            where=profile.locations[0] if profile.locations else None,
+            sort=params.sort,
+            max_days_old=params.max_days_old,
+            salary_min=profile.salary_min or None,
+        )
     except Exception:
         results = []
     pr = process(results, profile, params, cfg)
@@ -155,7 +164,16 @@ async def search_start(
     )
     params = SearchParams(max_days_old=cfg.search.max_days_old_default, sort="relevance")
     try:
-        results = await adzuna.search("gb", 1, cfg.search.results_per_page, what=profile.role, where=profile.locations[0] if profile.locations else None, sort=params.sort, max_days_old=params.max_days_old)
+        results = await adzuna.search(
+            "gb",
+            1,
+            cfg.search.results_per_page,
+            what=profile.role,
+            where=profile.locations[0] if profile.locations else None,
+            sort=params.sort,
+            max_days_old=params.max_days_old,
+            salary_min=profile.salary_min or None,
+        )
     except Exception:
         results = []
     pr = process(results, profile, params, cfg)

--- a/app/integrations/adzuna_client.py
+++ b/app/integrations/adzuna_client.py
@@ -41,6 +41,7 @@ class AdzunaClient:
         where: str | None = None,
         sort: str | None = None,
         max_days_old: int | None = None,
+        salary_min: int | None = None,
     ) -> list[dict[str, Any]]:
         base = self._settings.ADZUNA_BASE_URL.rstrip("/")
         url = f"{base}/{country}/search/{page}"
@@ -57,6 +58,8 @@ class AdzunaClient:
             params["sort_by"] = sort
         if max_days_old is not None:
             params["max_days_old"] = max_days_old
+        if salary_min is not None:
+            params["salary_min"] = salary_min
 
         client = self._client_or_create()
         backoffs = [0.2, 0.4, 0.8]

--- a/tests/test_adzuna_client.py
+++ b/tests/test_adzuna_client.py
@@ -1,0 +1,41 @@
+import pytest
+
+from app.integrations.adzuna_client import AdzunaClient
+from app.config import Settings, AppConfig
+
+
+class DummyResp:
+    def __init__(self):
+        self.called_params = None
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"results": []}
+
+
+class DummyClient:
+    def __init__(self, resp: DummyResp):
+        self.resp = resp
+
+    async def get(self, url, params):
+        self.resp.called_params = params
+        return self.resp
+
+    async def aclose(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_search_passes_salary_min(monkeypatch):
+    settings = Settings(ADZUNA_APP_ID="id", ADZUNA_APP_KEY="key")
+    cfg = AppConfig()
+    client = AdzunaClient(settings, cfg)
+    resp = DummyResp()
+    dummy = DummyClient(resp)
+    monkeypatch.setattr(client, "_client_or_create", lambda: dummy)
+
+    await client.search("gb", 1, 10, salary_min=1234)
+
+    assert resp.called_params["salary_min"] == 1234


### PR DESCRIPTION
## Summary
- Support salary_min parameter in AdzunaClient.search
- Pass user-configured minimum salary to Adzuna searches
- Cover salary filter propagation with a dedicated test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b82af8e8e08322864fe8712508f865