### PR TITLE
Start profile setup after language selection

### DIFF
--- a/app/bot/handlers/profile_wizard.py
+++ b/app/bot/handlers/profile_wizard.py
@@ -213,7 +213,8 @@ async def pf_pick_experience(cq: CallbackQuery, state: FSMContext, session, t, l
     await session.commit()
     # Clear temp
     await state.update_data(pf={})
-    # Replace the whole block with the main menu
+    # Replace the whole block with the main menu and explanation
     kb = with_lang_row(main_menu_kb(t), lang, t)
-    await cq.message.edit_text(t("menu.title"), reply_markup=kb)
+    text = f"{t('menu.title')}\n{t('menu.sub')}"
+    await cq.message.edit_text(text, reply_markup=kb)
     await cq.answer("")


### PR DESCRIPTION
## Summary
- Start profile setup wizard right after user selects interface language
- Show menu description after completing setup and on `/menu`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b82def2a6883229012f21bb7cb9d5f