### PR TITLE
feat: add inline settings menu

### DIFF
--- a/app/bot/i18n/en.json
+++ b/app/bot/i18n/en.json
@@ -108,7 +108,7 @@
   "errors.ratelimit": "⏱ Too many requests. Try later.",
 
   "help.title": "❓ Help",
-  "help.commands": "/find /profile /subscribe /favorites /settings /help",
+  "help.commands": "/find /subscribe /favorites /settings /help",
   "help.source": "Source: Adzuna. Algorithm: filter → dedup → scoring.",
 
   "about.title": "ℹ️ About",
@@ -135,5 +135,8 @@
   "buttons.subs.daily": "🗓 Daily",
   "buttons.subs.weekly": "📅 Weekly",
   "buttons.subs.toggle": "🔔 On/Off",
-  "buttons.subs.time": "⏰ Change time"
+  "buttons.subs.time": "⏰ Change time",
+  "buttons.settings.role": "✏️ Role",
+  "buttons.settings.location": "📍 Location",
+  "buttons.settings.reset": "♻️ Reset"
 }

--- a/app/bot/i18n/ru.json
+++ b/app/bot/i18n/ru.json
@@ -108,7 +108,7 @@
   "errors.ratelimit": "⏱ Слишком много запросов. Повторите позже.",
 
   "help.title": "❓ Помощь",
-  "help.commands": "/find /profile /subscribe /favorites /settings /help",
+  "help.commands": "/find /subscribe /favorites /settings /help",
   "help.source": "Источник: Adzuna. Алгоритм: фильтр → дедуп → скоринг.",
 
   "about.title": "ℹ️ О боте",
@@ -135,5 +135,8 @@
   "buttons.subs.daily": "🗓 Ежедневно",
   "buttons.subs.weekly": "📅 Еженедельно",
   "buttons.subs.toggle": "🔔 Вкл/Выкл",
-  "buttons.subs.time": "⏰ Изменить время"
+  "buttons.subs.time": "⏰ Изменить время",
+  "buttons.settings.role": "✏️ Роль",
+  "buttons.settings.location": "📍 Локация",
+  "buttons.settings.reset": "♻️ Сброс"
 }

--- a/app/bot/keyboards.py
+++ b/app/bot/keyboards.py
@@ -54,4 +54,19 @@ def with_lang_row(markup: InlineKeyboardMarkup, lang: str, t=None) -> InlineKeyb
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
+def settings_kb(t) -> InlineKeyboardMarkup:
+    """Inline keyboard for settings menu."""
+    labels = (
+        t("buttons.settings.role") if callable(getattr(t, "__call__", None)) else "✏️ Роль",
+        t("buttons.settings.location") if callable(getattr(t, "__call__", None)) else "📍 Локация",
+        t("buttons.settings.reset") if callable(getattr(t, "__call__", None)) else "♻️ Сброс",
+    )
+    kb = [
+        [InlineKeyboardButton(text=labels[0], callback_data="settings:role")],
+        [InlineKeyboardButton(text=labels[1], callback_data="settings:location")],
+        [InlineKeyboardButton(text=labels[2], callback_data="settings:reset")],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=kb)
+
+
 # Profile wizard keyboards removed as search now collects data sequentially


### PR DESCRIPTION
## Summary
- implement inline settings keyboard for editing role/location or resetting filters
- update translations and remove obsolete /profile command from help

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8844a71688322a2bf7268d737b4fa